### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/lib/actions/email.server.actions.ts
+++ b/lib/actions/email.server.actions.ts
@@ -58,7 +58,8 @@ export async function sendScheduledEmailsBeforeSessions(
           const data = await response.json();
         } catch (sessionError) {
           console.error(
-            `Error processing session ${session.id}:`,
+            "Error processing session %s:",
+            session.id,
             sessionError
           );
           // Continue processing other sessions instead of failing entirely


### PR DESCRIPTION
Potential fix for [https://github.com/hujalex/connect-me-app/security/code-scanning/3](https://github.com/hujalex/connect-me-app/security/code-scanning/3)

To fix the problem, we must ensure that any potentially user-controlled value interpolated into a format string that is passed to a printf-like function (such as `console.error`) is not allowed to inject format specifiers. Instead, we should use a static format string with `%s` as needed, and pass the dynamic value as additional arguments. Specifically, on line 61, change:

```js
console.error(
  `Error processing session ${session.id}:`,
  sessionError
);
```

to:

```js
console.error(
  "Error processing session %s:",
  session.id,
  sessionError
);
```

This way, regardless of the value of `session.id`, it will be safely injected as a string where the `%s` specifier appears, preventing any accidental or intentional insertion of format string control sequences.

No additional imports or methods are required; this is a single-line change inside the `lib/actions/email.server.actions.ts` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
