### PR TITLE
Refactor date-fns import in ScheduleManagement

### DIFF
--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -12,7 +12,8 @@ import {
   isValid,
   previousDay,
 } from "date-fns";
-import * as DateFns from "date-fns-tz";
+import { toZonedTime } from "date-fns-tz";
+// import * as DateFns from "date-fns-tz";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -77,7 +78,7 @@ import {
 import { Textarea } from "../ui/textarea";
 import { boolean } from "zod";
 
-const { toZonedTime } = DateFns;
+// const { toZonedTime } = DateFns;
 
 const Schedule = () => {
   const [currentWeek, setCurrentWeek] = useState(new Date());


### PR DESCRIPTION
Removed unused import of DateFns and switched to named import for toZonedTime.